### PR TITLE
Missing include statement causing compilation error

### DIFF
--- a/src/MinerProtocol.h
+++ b/src/MinerProtocol.h
@@ -9,6 +9,7 @@
 #ifndef cryptoport_MinerProtocol_h
 #define cryptoport_MinerProtocol_h
 #include "Miner.h"
+#include <functional>
 
 namespace Burst
 {


### PR DESCRIPTION
Error occurs while attempting to compile miner (arch linux, gcc 7.3.1)

```
➜  BurstMiner git:(master) make
g++ -O3 -march=native -std=c++11 -Wall -D_REENTRANT -Isrc/rapidjson -Isrc/sphlib -Isrc/nxt -Isrc -c src/sphlib/sph_shabal.cpp -o bin/sphlib/sph_shabal.o
g++ -O3 -march=native -std=c++11 -Wall -D_REENTRANT -Isrc/rapidjson -Isrc/sphlib -Isrc/nxt -Isrc -c src/nxt/nxt_address.cpp -o bin/nxt/nxt_address.o
g++ -O3 -march=native -std=c++11 -Wall -D_REENTRANT -Isrc/rapidjson -Isrc/sphlib -Isrc/nxt -Isrc -c src/MinerLogger.cpp -o bin/MinerLogger.o
In file included from src/Miner.h:90:0,
                 from src/MinerLogger.cpp:9:
src/MinerProtocol.h:21:79: error: ‘std::function’ has not been declared
 Async(const std::string url, const std::string body,std::function< void ( std::string ) > responseCallback);
                                                          ^~~~~~~~
src/MinerProtocol.h:21:87: error: expected ‘,’ or ‘...’ before ‘<’ token
 nst std::string url, const std::string body,std::function< void ( std::string ) > responseCallback);
                                                          ^
In file included from src/Miner.h:90:0,
                 from src/MinerLogger.cpp:9:
src/MinerProtocol.h:22:54: error: ‘std::function’ has not been declared
         void httpGetAsync(const std::string url,std::function< void ( std::string ) > responseCallback);
                                                      ^~~~~~~~
src/MinerProtocol.h:22:62: error: expected ‘,’ or ‘...’ before ‘<’ token
     void httpGetAsync(const std::string url,std::function< void ( std::string ) > responseCallback);
                                                          ^
src/MinerProtocol.h:28:36: error: ‘std::function’ has not been declared
                               std::function< void ( std::string ) > responseCallback );
                                    ^~~~~~~~
src/MinerProtocol.h:28:44: error: expected ‘,’ or ‘...’ before ‘<’ token
                               std::function< void ( std::string ) > responseCallback );
                                            ^
```